### PR TITLE
BUG: Lesson 7 - Added uid to addIncomeItem

### DIFF
--- a/lib/store/finance-context.js
+++ b/lib/store/finance-context.js
@@ -121,10 +121,13 @@ export default function FinanceContextProvider({ children }) {
   };
 
   const addIncomeItem = async (newIncome) => {
-    const collectionRef = collection(db, "income");
-
     try {
-      const docSnap = await addDoc(collectionRef, newIncome);
+      const collectionRef = collection(db, "income");
+      
+      const docSnap = await addDoc(collectionRef, {
+        uid: user.uid,
+        ...newIncome,
+      });
 
       // Update state
       setIncome((prevState) => {
@@ -132,6 +135,7 @@ export default function FinanceContextProvider({ children }) {
           ...prevState,
           {
             id: docSnap.id,
+            uid: user.id,
             ...newIncome,
           },
         ];


### PR DESCRIPTION
I noticed during testing that the income items entered were disappearing after refreshing the browser window. Watching lesson 7 back again and I think it may have been inadvertently missed.

I have not done a pull request before so I hope it is appropriate and contains sufficient information. 